### PR TITLE
Update navigation link label from "Contacts" to "Socials"

### DIFF
--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -78,7 +78,7 @@
             <li class="nav-item">
                 <a class="nav-link" href="">
                     <i class="far fa-address-card"></i>
-                    <span>Contacts</span></a>
+                    <span>Socials</span></a>
             </li>
 
 


### PR DESCRIPTION
This pull request updates the navigation link label from "Contacts" to "Socials". This change ensures that the link accurately reflects the content it leads to.